### PR TITLE
feat: add CodSpeed performance testing integration

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,26 @@
+name: CodSpeed
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: moonrepo/setup-rust@v1
+        with:
+          channel: stable
+          cache-target: release
+          bins: cargo-codspeed
+      - name: Build benchmarks
+        run: cargo codspeed build
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v3
+        with:
+          run: cargo codspeed run
+          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/kcl-ezpz/Cargo.toml
+++ b/kcl-ezpz/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "2.0.14"
 winnow = { version = "0.7.13" }
 
 [dev-dependencies]
-criterion = "0.7.0"
+criterion = { package = "codspeed-criterion-compat", version = "3.0" }
 
 [[bench]]
 name = "solver_bench"


### PR DESCRIPTION
## Summary
- Integrates CodSpeed continuous performance testing platform
- Replaces criterion dependency with codspeed-criterion-compat for accurate CI benchmarking
- Adds GitHub Actions workflow for automated performance tracking

## Changes Made
- **Dependencies**: Updated `kcl-ezpz/Cargo.toml` to use `codspeed-criterion-compat` v3.0
- **CI/CD**: Created `.github/workflows/codspeed.yml` with cargo-codspeed integration
- **Compatibility**: Existing 8 benchmark functions work without modification

## Next Steps
1. Set up CodSpeed account and obtain CODSPEED_TOKEN
2. Add CODSPEED_TOKEN to repository secrets
3. Monitor performance regressions in future PRs

The existing benchmarks (solve_tiny, solve_two_rectangles, etc.) will now provide accurate, noise-free performance measurements in CI environments.